### PR TITLE
create stop-instance.sh script, modify image builder to create safe_t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ create-standard-instance.sh - takes two mandatory parameters, the name of the ba
 
 The script create-spot-instance.sh functions like 'create-standard-instance.sh', only difference being that it utilizes the AMI created by the image builder pipeline. Environment variables can be used to control spot requests, namely block duration, please take of look at the script content, and notice use of environment variables there-in.
 
+### Stopping training
+
+The script stop-instance.sh executes 'safe termination' of training and deletes the cloudformation stack used to create the instance. This command works for both standard and spot instances. The scripts takes one parameter, the name of the stack used to create the instance (this is the same as the second parameter to used to create the instance with either create-standard-instance.sh or create-spot-instance.sh commands). For example: ./stop-instance.sh my-instance-stack-name
+
 ### Adding additional IP addresses to security group ingress and NACLs
 
 The script add-access.sh adds an additional IP address to the security group ingress, it also add an NACL entry. Use:  ./add-access.sh <base resources stack name> <stack name> <IP address>

--- a/add-access.yaml
+++ b/add-access.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: Setup an EC2 instance for deep racer
+Description: Add access
 
 Parameters:
   ResourcesStackName:

--- a/image-builder.yaml
+++ b/image-builder.yaml
@@ -411,6 +411,33 @@ Resources:
                           export PATH=/home/ubuntu/bin:$PATH
         - BUCKET: !ImportValue
             Fn::Sub: ${ResourcesStackName}-Bucket
+  SafeTerminationComponent:
+    Type: AWS::ImageBuilder::Component
+    Properties:
+      Name: SafeTermination
+      Version: '0.0.2'
+      Description: Install script to terminate training and upload model.
+      ChangeDescription: First version
+      Platform: Linux
+      Data: |
+        name: SafeTermination
+        description: terminates training
+        schemaVersion: 1.0
+        phases:
+          - name: build
+            steps:
+              - name: SafeTermination
+                action: CreateFile
+                inputs:
+                  - path: /home/ubuntu/bin/safe_termination.sh
+                    permissions: 775
+                    owner: ubuntu
+                    group: ubuntu
+                    content: |
+                      #!/bin/bash
+                      . /home/ubuntu/deepracer-for-cloud/bin/activate.sh
+                      dr-stop-training
+                      dr-upload-model -bf
   UbuntuServerForDeepRacerImageRecipe:
     Type: AWS::ImageBuilder::ImageRecipe
     Properties:
@@ -420,6 +447,7 @@ Resources:
       Components:
         - ComponentArn: !Ref 'CreateLogsComponent'
         - ComponentArn: !Ref 'DeepracerS3URIComponent'
+        - ComponentArn: !Ref 'SafeTerminationComponent'
         - ComponentArn: !Ref 'InstallEFSUtilsComponent'
         - ComponentArn: !Ref 'ExpandRootVolumeComponent'
         - ComponentArn: !Ref 'InstallDeepRacerDockerImagesScriptComponent'

--- a/spot-instance.yaml
+++ b/spot-instance.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: Setup a standard EC2 instance for deep racer
+Description: Setup a spot EC2 instance for deep racer
 
 Parameters:
   InstanceType:
@@ -183,7 +183,7 @@ Resources:
                   response = ssm_client.send_command(
                       InstanceIds=[instance_id],
                       DocumentName='AWS-RunShellScript',
-                      Parameters={'commands': ['/home/ubuntu/bin/interrupt_spot.sh']},
+                      Parameters={'commands': ['su - ubuntu bash -lc /home/ubuntu/bin/safe_termination.sh']},
                       CloudWatchOutputConfig={'CloudWatchOutputEnabled': True},
                       TimeoutSeconds=60)
                   print(f'Running commands on instance {instance_id}. Command id: {id}')


### PR DESCRIPTION
…ermination.sh on AMI

To make use of this, the image-builder pipeline stack has to be deleted and recreated. That will ensure that the next AMI created will contain the /home/ubuntu/bin/safe_termination.sh script used when stopping an instance.  The script is also used when a spot instance is termination due to instance eviction.