### PR TITLE
Added missing TimeToLiveInMinutes param to spot instance shell script

### DIFF
--- a/create-spot-instance.sh
+++ b/create-spot-instance.sh
@@ -8,19 +8,20 @@ shift
 stackName=$1
 shift
 
+timeToLiveInMinutes=$1
+shift
+
 instanceTypeConfig=''
 
 if [[ -n "$DEEPRACER_INSTANCE_TYPE" ]]; then
        instanceTypeConfig="InstanceType=$DEEPRACER_INSTANCE_TYPE"
 fi
-
-
 BUCKET=$(aws cloudformation describe-stacks --stack-name $baseResourcesStackName | jq '.Stacks | .[] | .Outputs | .[] | select(.OutputKey=="Bucket") | .OutputValue' | tr -d '"') 
 set +x
 . ./validation.sh
 set -x
 aws s3 cp custom-files s3://${BUCKET}/custom_files --recursive
-aws cloudformation deploy --stack-name $stackName --parameter-overrides ${instanceTypeConfig} ResourcesStackName=$baseResourcesStackName --template-file spot-instance.yaml --capabilities CAPABILITY_IAM
+aws cloudformation deploy --stack-name $stackName --parameter-overrides ${instanceTypeConfig} ResourcesStackName=$baseResourcesStackName TimeToLiveInMinutes=$timeToLiveInMinutes --template-file spot-instance.yaml --capabilities CAPABILITY_IAM
 EC2_IP=`aws cloudformation list-exports --query "Exports[?Name=='${stackName}-PublicIp'].Value" --no-paginate --output text`
 echo "Logs will upload every 2 minutes to https://s3.console.aws.amazon.com/s3/buckets/${BUCKET}/${stackName}/logs/"
 echo "Training should start shortly on ${EC2_IP}:8080"


### PR DESCRIPTION
Not sure if this was intentional but seems spot instances currently do not honor TTL. If this was intentional, please reject this PR.