### PR TITLE
Feature/sourceImage - get AMI from a single source account instead of everyone having to run image builder

### DIFF
--- a/create-spot-instance.sh
+++ b/create-spot-instance.sh
@@ -40,7 +40,7 @@ fi
 set -x
 
 aws s3 cp custom-files s3://${BUCKET}/custom_files --recursive
-aws cloudformation deploy --stack-name $stackName --parameter-overrides ${instanceTypeConfig} ResourcesStackName=$baseResourcesStackName TimeToLiveInMinutes=$timeToLiveInMinutes AmiId=$amiId --template-file spot-instance.yaml --capabilities CAPABILITY_IAM
+aws cloudformation deploy --stack-name $stackName --parameter-overrides ${instanceTypeConfig} ResourcesStackName=$baseResourcesStackName TimeToLiveInMinutes=$timeToLiveInMinutes AmiId=$amiId BUCKET=$BUCKET --template-file spot-instance.yaml --capabilities CAPABILITY_IAM
 EC2_IP=`aws cloudformation list-exports --query "Exports[?Name=='${stackName}-PublicIp'].Value" --no-paginate --output text`
 echo "Logs will upload every 2 minutes to https://s3.console.aws.amazon.com/s3/buckets/${BUCKET}/${stackName}/logs/"
 echo "Training should start shortly on ${EC2_IP}:8080"

--- a/create-standard-instance.sh
+++ b/create-standard-instance.sh
@@ -42,7 +42,7 @@ fi
 set -x
 
 aws s3 cp custom-files s3://${BUCKET}/custom_files --recursive
-aws cloudformation deploy --stack-name $stackName --parameter-overrides ${instanceTypeConfig} ResourcesStackName=$baseResourcesStackName TimeToLiveInMinutes=$timeToLiveInMinutes AmiId=$amiId --template-file standard-instance.yaml
+aws cloudformation deploy --stack-name $stackName --parameter-overrides ${instanceTypeConfig} ResourcesStackName=$baseResourcesStackName TimeToLiveInMinutes=$timeToLiveInMinutes AmiId=$amiId BUCKET=$BUCKET --template-file standard-instance.yaml
 EC2_IP=`aws cloudformation list-exports --query "Exports[?Name=='${stackName}-PublicIp'].Value" --no-paginate --output text`
 echo "Logs will upload every 2 minutes to https://s3.console.aws.amazon.com/s3/buckets/${BUCKET}/${stackName}/logs/"
 echo "Training should start shortly on ${EC2_IP}:8080"

--- a/create-standard-instance.sh
+++ b/create-standard-instance.sh
@@ -17,6 +17,7 @@ if [[ -n "$DEEPRACER_INSTANCE_TYPE" ]]; then
     instanceTypeConfig="InstanceType=$DEEPRACER_INSTANCE_TYPE"
 fi
 BUCKET=$(aws cloudformation describe-stacks --stack-name $baseResourcesStackName | jq '.Stacks | .[] | .Outputs | .[] | select(.OutputKey=="Bucket") | .OutputValue' | tr -d '"')
+amiId=$(aws ec2 describe-images --owners 747447086422 --query 'sort_by(Images, &CreationDate)[0].ImageId' | tr -d '"')
 
 set +xa
 
@@ -39,7 +40,7 @@ fi
 set -x
 
 aws s3 cp custom-files s3://${BUCKET}/custom_files --recursive
-aws cloudformation deploy --stack-name $stackName --parameter-overrides ${instanceTypeConfig} ResourcesStackName=$baseResourcesStackName TimeToLiveInMinutes=$timeToLiveInMinutes --template-file standard-instance.yaml
+aws cloudformation deploy --stack-name $stackName --parameter-overrides ${instanceTypeConfig} ResourcesStackName=$baseResourcesStackName TimeToLiveInMinutes=$timeToLiveInMinutes AmiId=$amiId --template-file standard-instance.yaml
 EC2_IP=`aws cloudformation list-exports --query "Exports[?Name=='${stackName}-PublicIp'].Value" --no-paginate --output text`
 echo "Logs will upload every 2 minutes to https://s3.console.aws.amazon.com/s3/buckets/${BUCKET}/${stackName}/logs/"
 echo "Training should start shortly on ${EC2_IP}:8080"

--- a/image-builder.yaml
+++ b/image-builder.yaml
@@ -416,17 +416,17 @@ Resources:
                       fi
                       dr-upload-model -bfw
                       dr-stop-training
-  DistributionConfigution:
+  DistributionConfiguration:
     Type: 'AWS::ImageBuilder::DistributionConfiguration'
     Properties:
       Name: !Sub 'DistributionConfiguration-${AWS::StackName}'
       Distributions:
-        -Region: 'us-east-1'
-        AmiDistributionConfiguration:
-          Name: 'ami-dist-config-us-east-1'
-          LaunchPermissionConfiguration:
-            UserGroups:
-              - 'all'
+        - Region: 'us-east-1'
+          AmiDistributionConfiguration:
+            Name: 'ami-dist-config-us-east-1 {{ imagebuilder:buildDate }}'
+            LaunchPermissionConfiguration:
+              UserGroups:
+                - all
   UbuntuServerForDeepRacerImageRecipe:
     Type: AWS::ImageBuilder::ImageRecipe
     Properties:
@@ -448,6 +448,7 @@ Resources:
       Description: DeepRacer image build pipeline
       ImageRecipeArn: !Ref 'UbuntuServerForDeepRacerImageRecipe'
       InfrastructureConfigurationArn: !Ref 'UbuntuServerImageInfrastructureConfiguration'
+      DistributionConfigurationArn: !Ref 'DistributionConfiguration'
       Name: !Sub 'DeepRacerImageBuildPipeline-${AWS::StackName}'
       Tags:
         BuildStack: !Sub '${AWS::StackName}'

--- a/image-builder.yaml
+++ b/image-builder.yaml
@@ -383,35 +383,6 @@ Resources:
                     - "bash -c '/home/ubuntu/bin/pull-docker-images.sh -n awsdeepracercommunity/deepracer-robomaker -v -f -cpu-avx2'"
                     - "bash -c '/home/ubuntu/bin/pull-docker-images.sh -n awsdeepracercommunity/deepracer-sagemaker -v -f -gpu'"
                     - "bash -c '/home/ubuntu/bin/pull-docker-images.sh -n awsdeepracercommunity/deepracer-rlcoach -v'"
-  DeepracerS3URIComponent:
-    Type: AWS::ImageBuilder::Component
-    Properties:
-      Name: !Sub 'DeepRacerS3URI-${AWS::StackName}'
-      Version: '0.0.2'
-      Description: Install the latest DeepRacer docker images script.
-      ChangeDescription: First version
-      Platform: Linux
-      Data: !Sub
-        - |
-          name: DeepRacerS3URI
-          description: Creates an envrironment variable for DR_S3_URI
-          schemaVersion: 1.0
-          phases:
-            - name: build
-              steps:
-                - name: DeepRacerS3URI
-                  action: CreateFile
-                  inputs:
-                    - path: /etc/profile.d/s3_uri.sh
-                      permissions: 775
-                      owner: root
-                      group: root
-                      content: |
-                          export DR_S3_URI=${BUCKET}
-                          export DEEPRACER_S3_URI=${BUCKET}
-                          export PATH=/home/ubuntu/bin:$PATH
-        - BUCKET: !ImportValue
-            Fn::Sub: ${ResourcesStackName}-Bucket
   SafeTerminationComponent:
     Type: AWS::ImageBuilder::Component
     Properties:
@@ -445,8 +416,17 @@ Resources:
                       fi
                       dr-upload-model -bfw
                       dr-stop-training
-                      aws s3 cp /tmp/logs/ s3://$DEEPRACER_S3_URI/$DR_LOCAL_S3_MODEL_PREFIX/logs/ --recursive
-                      rm -rf /tmp/logs/
+  DistributionConfigution:
+    Type: 'AWS::ImageBuilder::DistributionConfiguration'
+    Properties:
+      Name: !Sub 'DistributionConfiguration-${AWS::StackName}'
+      Distributions:
+        -Region: 'us-east-1'
+        AmiDistributionConfiguration:
+          Name: 'ami-dist-config-us-east-1'
+          LaunchPermissionConfiguration:
+            UserGroups:
+              - 'all'
   UbuntuServerForDeepRacerImageRecipe:
     Type: AWS::ImageBuilder::ImageRecipe
     Properties:
@@ -455,7 +435,6 @@ Resources:
       ParentImage: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:image/ubuntu-server-18-lts-x86/x.x.x'
       Components:
         - ComponentArn: !Ref 'CreateLogsComponent'
-        - ComponentArn: !Ref 'DeepracerS3URIComponent'
         - ComponentArn: !Ref 'SafeTerminationComponent'
         - ComponentArn: !Ref 'InstallEFSUtilsComponent'
         - ComponentArn: !Ref 'ExpandRootVolumeComponent'

--- a/spot-instance.yaml
+++ b/spot-instance.yaml
@@ -16,7 +16,8 @@ Parameters:
   AmiId:
     Type: String
     Description: the AMI we want to launch an ec2 instance against. By default this is the image created by central account 747447086422 owned by Tyler Wooten
-
+  BUCKET:
+    Type: String
 
 Outputs:
 
@@ -336,7 +337,11 @@ Resources:
         Fn::Base64: !Sub |
           #!/bin/bash -xe
           /usr/local/bin/cfn-init --stack ${AWS::StackName} --resource Instance --region ${AWS::Region}
-
+          bash
+          sudo su ubuntu
+          cd /home/ubuntu/deepracer-for-cloud/
+          source bin/activate.sh
+          export DEEPRACER_S3_URI=${BUCKET}
 
   SpotInterruptionHandlerFunction:
     Type: AWS::Lambda::Function

--- a/standard-instance.yaml
+++ b/standard-instance.yaml
@@ -101,8 +101,6 @@ Resources:
               content:
                 Fn::Sub:
                 - "export MY_BUCKET=${BUCKET}"
-                - "export DR_S3_URI=${BUCKET}"
-                - "export DEEPRACER_S3_URI=${BUCKET}"
                 - BUCKET:
                        Fn::ImportValue:
                            !Sub "${ResourcesStackName}-Bucket"

--- a/standard-instance.yaml
+++ b/standard-instance.yaml
@@ -4,7 +4,7 @@ Description: Setup a standard EC2 instance for deep racer
 Parameters:
   InstanceType:
     Type: String
-    Default: g4dn.4xlarge
+    Default: g4dn.2xlarge
   ResourcesStackName:
     Type: String
   TimeToLiveInMinutes:
@@ -13,6 +13,9 @@ Parameters:
     Default: 60
     MinValue: 0
     MaxValue: 1440 # 24 hours
+  AmiId:
+    Type: String
+    Description: the AMI we want to launch an ec2 instance against. By default this is the image created by central account 747447086422
 
 Outputs:
 
@@ -39,7 +42,7 @@ Resources:
           Name:
             !ImportValue
             'Fn::Sub': '${ResourcesStackName}-InstanceProfile'
-        ImageId: !Sub '{{resolve:ssm:/DeepRacer/Images/${ResourcesStackName}}}'
+        ImageId: !Ref AmiId
         InstanceType: !Ref InstanceType
         BlockDeviceMappings:
           - DeviceName: /dev/sda1

--- a/standard-instance.yaml
+++ b/standard-instance.yaml
@@ -101,6 +101,8 @@ Resources:
               content:
                 Fn::Sub:
                 - "export MY_BUCKET=${BUCKET}"
+                - "export DR_S3_URI=${BUCKET}"
+                - "export DEEPRACER_S3_URI=${BUCKET}"
                 - BUCKET:
                        Fn::ImportValue:
                            !Sub "${ResourcesStackName}-Bucket"

--- a/standard-instance.yaml
+++ b/standard-instance.yaml
@@ -16,6 +16,8 @@ Parameters:
   AmiId:
     Type: String
     Description: the AMI we want to launch an ec2 instance against. By default this is the image created by central account 747447086422 owned by Tyler Wooten
+  BUCKET:
+    Type: String
 
 Outputs:
 
@@ -328,6 +330,11 @@ Resources:
         Fn::Base64: !Sub |
           #!/bin/bash -xe
           /usr/local/bin/cfn-init --stack ${AWS::StackName} --resource Instance --region ${AWS::Region}
+          bash
+          sudo su ubuntu
+          cd /home/ubuntu/deepracer-for-cloud/
+          source bin/activate.sh
+          export DEEPRACER_S3_URI=${BUCKET}
 
   TerminationCronExpression:
     Type: Custom::TerminationCronExpression

--- a/standard-instance.yaml
+++ b/standard-instance.yaml
@@ -100,11 +100,7 @@ Resources:
             /etc/profile.d/my_bucket.sh:
               content:
                 Fn::Sub:
-<<<<<<< HEAD
-                - "export MY_BUCKET=${BUCKET}"
-=======
                 - "export MY_BUCKET=${BUCKET};export DR_S3_URI=${BUCKET};export DEEPRACER_S3_URI=${BUCKET}"
->>>>>>> tmp
                 - BUCKET:
                        Fn::ImportValue:
                            !Sub "${ResourcesStackName}-Bucket"


### PR DESCRIPTION
For each user to run the image builder, there is a daily cost for the image pipeline to run and this cost can deter many users. Now, one central account will run the image builder pipeline, and every standard/spot instance created will run off of this central AMI. 

By not having users run the image builder, we can also reduce the time to start training. A user can create base resources and immediately run a spot/standard instance